### PR TITLE
Export types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,12 +6,12 @@ import isBrowser from './isBrowser.macro'
 const MOUSEDOWN = 'mousedown'
 const TOUCHSTART = 'touchstart'
 
-type HandledEvents = [typeof MOUSEDOWN, typeof TOUCHSTART]
-type HandledEventsType = HandledEvents[number]
-type PossibleEvent = {
+export type HandledEvents = [typeof MOUSEDOWN, typeof TOUCHSTART]
+export type HandledEventsType = HandledEvents[number]
+export type PossibleEvent = {
   [Type in HandledEventsType]: HTMLElementEventMap[Type]
 }[HandledEventsType]
-type Handler = (event: PossibleEvent) => void
+export type Handler = (event: PossibleEvent) => void
 
 const events: HandledEvents = [MOUSEDOWN, TOUCHSTART]
 


### PR DESCRIPTION
Right now I want to get `PossibleEvent` to pass it back to another function. Right now I am doing it with `Parameters<NonNullable<Parameters<typeof useOnClickOutside>[1]>>[0]` which I personally think should not be done.

As other types might come in handy, I also exposed them